### PR TITLE
Optionally add prometheus metrics endpoint

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -8,6 +8,7 @@ dependencies:
   - dials-data
   - fastapi
   - httpx
+  - prometheus-fastapi-instrumentator
   - pytest
   - python=3.10
   - python-dateutil

--- a/environment.yml
+++ b/environment.yml
@@ -6,6 +6,7 @@ channels:
 dependencies:
   - dials>=3.14
   - fastapi
+  - prometheus-fastapi-instrumentator
   - python=3.10
   - python-dateutil
   - python-jose

--- a/src/dials_rest/main.py
+++ b/src/dials_rest/main.py
@@ -13,6 +13,15 @@ app = FastAPI()
 app.include_router(find_spots.router)
 app.include_router(image.router)
 
+if settings.enable_metrics:
+    from prometheus_fastapi_instrumentator import Instrumentator
+
+    instrumentator = Instrumentator(
+        excluded_handlers=["/metrics"],
+    )
+    instrumentator.instrument(app)
+    instrumentator.expose(app)
+
 
 @app.get("/")
 async def root():

--- a/src/dials_rest/settings.py
+++ b/src/dials_rest/settings.py
@@ -2,11 +2,15 @@ from __future__ import annotations
 
 from functools import lru_cache
 
-from pydantic import BaseSettings
+from pydantic import BaseSettings, Field
 
 
 class Settings(BaseSettings):
     jwt_secret: str
+    enable_metrics: bool = Field(
+        default=False,
+        description="Expose metrics in prometheus format on the /metrics endpoint",
+    )
 
     @staticmethod
     @lru_cache
@@ -14,4 +18,5 @@ class Settings(BaseSettings):
         return Settings()
 
     class Config:
+        env_prefix = "DIALS_REST_"
         secrets_dir = "/opt/secrets"


### PR DESCRIPTION
Using [prometheus-fastapi-instrumentor](https://pypi.org/project/prometheus-fastapi-instrumentator/).
Set the environment variable `DIALS_REST_ENABLE_METRICS=1` to enable the /metrics endpoint.

The `JWT_SECRET` environment variable now has a `DIALS_REST_` prefix.