### PR TITLE
Fix OpenAPI schema generation

### DIFF
--- a/tests/routers/test_find_spots.py
+++ b/tests/routers/test_find_spots.py
@@ -1,8 +1,19 @@
+from __future__ import annotations
+
 import os
 from unittest import mock
 
 import pytest
 from fastapi import status
+
+
+def test_export_bitmap_params_schema(monkeypatch):
+    monkeypatch.setenv("DIALS_REST_JWT_SECRET", "FooBar")
+    from dials_rest.routers import find_spots
+
+    p = find_spots.PerImageAnalysisParameters(filename="/path/to/image.cbf")
+    p.json()
+    p.schema()
 
 
 def test_find_spots_file_not_found_responds_404(client, authentication_headers):

--- a/tests/routers/test_image.py
+++ b/tests/routers/test_image.py
@@ -1,9 +1,20 @@
+from __future__ import annotations
+
 import os
 from io import BytesIO
 
 import pytest
 from fastapi import status
 from PIL import Image
+
+
+def test_export_bitmap_params_schema(monkeypatch):
+    monkeypatch.setenv("DIALS_REST_JWT_SECRET", "FooBar")
+    from dials_rest.routers import image
+
+    p = image.ExportBitmapParams(filename="/path/to/image.cbf")
+    p.json()
+    p.schema()
 
 
 def test_export_bitmap_without_jwt_responds_401(client):


### PR DESCRIPTION
Use standard Python data types for unit_cell and space_group. Use of custom types with default values causes schema generation to fail (pydantic/pydantic#2470).